### PR TITLE
Fix/update to include all json files as invoice files

### DIFF
--- a/ClockifyUtility/Templates/invoice.config.template.json
+++ b/ClockifyUtility/Templates/invoice.config.template.json
@@ -1,9 +1,8 @@
 {
-  // Example client-specific invoice configuration for Clockify Invoice Generator
   "Clockify": {
     "ClockifyApiKey": "your-api-key-here",
-    "UserId": "your-user-id",
-    "WorkspaceId": "your-workspace-id",
+    "UserId": "",
+    "WorkspaceId": "",
     "FromName": "Your Name",
     "CompanyAddressLine1": "123 Main St",
     "CompanyAddressLine2": "Suite 456",
@@ -23,8 +22,8 @@
     "ClientNumber": "+11234567890",
     "CurrencySymbol": "$",
     "HourlyRate": 8.0,
-    "OutputPath": "D:/Invoices/2025",
-    "LogoPath": "./logo.png", // Optional: path to logo image
+    "OutputPath": "./InvoiceConfigs",
+    "LogoPath": "", 
     "ConstantLineItems": [
       {
         "Description": "GitHub Co-pilot ($10/month)",

--- a/ClockifyUtility/ViewModels/MainViewModel.cs
+++ b/ClockifyUtility/ViewModels/MainViewModel.cs
@@ -155,10 +155,11 @@ namespace ClockifyUtility.ViewModels
 			}
 			if ( !string.IsNullOrWhiteSpace ( invoiceConfigDir ) && System.IO.Directory.Exists ( invoiceConfigDir ) )
 			{
+				// Include ALL .json files, including appsettings.json
 				var files = System.IO.Directory.GetFiles(invoiceConfigDir, "*.json")
-					.Where(f => !System.IO.Path.GetFileName(f).StartsWith("appsettings.", StringComparison.OrdinalIgnoreCase))
+					.Select(f => System.IO.Path.GetFileName(f))
 					.ToList();
-				_availableInvoiceConfigs = files.Select ( f => System.IO.Path.GetFileName ( f ) ).ToList ( );
+				_availableInvoiceConfigs = files;
 			}
 			else
 			{

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The application requires an `appsettings.json` file in the same directory as the
 
 - `appsettings.template.json`
   - Used for application wide settings 
-- `AppSettings.template.invoice.json`
+- `invoice.config.template.json`
   - Used to setup an invoice. You can setup mutiple invoices by adding them to the `InvoiceConfigDirectory` with different configurations 
 
 #### App Settings:
@@ -38,7 +38,7 @@ Each invoice config file (e.g., `my-invoice.json`) should include your Clockify 
 
 **A template invoice config is provided:**
 
-- `AppSettings.template.invoice.json`
+- `invoice.config.template.json`
 
 Copy and rename this file for each client/project, then edit the details.
 


### PR DESCRIPTION
- Update to accept all JSON files as invoice config files. Previously, excluded appsettings.json files. 
- Rename config file template to invoice.config.tenplate.json and updated README to reflect the change. 