### PR TITLE
Update Topmost behavior in ClockifyIdDialog

### DIFF
--- a/ClockifyUtility/Views/ClockifyIdDialog.xaml.cs
+++ b/ClockifyUtility/Views/ClockifyIdDialog.xaml.cs
@@ -22,6 +22,7 @@ namespace ClockifyUtility.Views
 			{
 				this.Owner = owner;
 				this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+				this.Topmost = owner.IsActive; // Initialize Topmost based on owner's current activity state
 				// Only set Topmost to true while the owner window is active
 				owner.Activated += (s, e) => this.Topmost = true;
 				owner.Deactivated += (s, e) => this.Topmost = false;

--- a/ClockifyUtility/Views/ClockifyIdDialog.xaml.cs
+++ b/ClockifyUtility/Views/ClockifyIdDialog.xaml.cs
@@ -22,7 +22,13 @@ namespace ClockifyUtility.Views
 			{
 				this.Owner = owner;
 				this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
-				this.Topmost = true;
+				// Only set Topmost to true while the owner window is active
+				owner.Activated += (s, e) => this.Topmost = true;
+				owner.Deactivated += (s, e) => this.Topmost = false;
+				this.Closed += (s, e) => {
+					owner.Activated -= (s2, e2) => this.Topmost = true;
+					owner.Deactivated -= (s2, e2) => this.Topmost = false;
+				};
 			}
 		}
 


### PR DESCRIPTION
Modify the `Topmost` property to be true only when the owner window is active. Added event handlers for `Activated` and `Deactivated` events to manage the `Topmost` state, and ensure they are removed when the dialog is closed to prevent memory leaks.