### PR TITLE
Redesign UI with modern theming

### DIFF
--- a/ClockifyUtility/App.xaml
+++ b/ClockifyUtility/App.xaml
@@ -6,15 +6,14 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <!-- Merge the color palette -->
+            <!-- Merge shared control resources -->
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Colors.xaml"/>
                 <ResourceDictionary Source="Themes/CustomComboBox.xaml"/>
                 <ResourceDictionary Source="Themes/PaletteComboBox.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
             <!-- System highlight overrides (MUST precede usage) -->
-            <Color x:Key="{x:Static SystemColors.HighlightColorKey}">#1e408c</Color>
+            <Color x:Key="{x:Static SystemColors.HighlightColorKey}">#1e3a8a</Color>
             <Color x:Key="{x:Static SystemColors.HighlightTextColorKey}">#FFFFFF</Color>
 
             <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"/>
@@ -25,19 +24,16 @@
             <FontFamily x:Key="FontAwesomeRegular">/Fonts/Font Awesome 6 Free-Regular-400.otf#Font Awesome 6 Free Regular</FontFamily>
             <FontFamily x:Key="FontAwesomeSolid">/Fonts/Font Awesome 6 Free-Solid-900.otf#Font Awesome 6 Free Solid</FontFamily>
 
-            <!-- Button Hover Highlight Color -->
-            <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#1e408c"/>
-
             <!-- Month selector buttons -->
             <Style x:Key="MonthSelectorButtonStyle" TargetType="Button">
-                <Setter Property="Background" Value="{StaticResource PrimaryBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource PrimaryBrush}"/>
                 <Setter Property="BorderBrush" Value="Transparent"/>
                 <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
                 <Setter Property="FontFamily" Value="{StaticResource FontAwesomeRegular}"/>
                 <Setter Property="FontSize" Value="19"/>
-                <Setter Property="Width" Value="34"/>
-                <Setter Property="Height" Value="26"/>
+                <Setter Property="Width" Value="38"/>
+                <Setter Property="Height" Value="32"/>
                 <Setter Property="Margin" Value="0"/>
                 <Setter Property="Template">
                     <Setter.Value>
@@ -45,7 +41,7 @@
                             <Border Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="2">
+                                    CornerRadius="6">
                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
                         </ControlTemplate>
@@ -53,7 +49,10 @@
                 </Setter>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="{StaticResource ButtonHoverHighlightBrush}"/>
+                        <Setter Property="Background" Value="{DynamicResource ButtonHoverHighlightBrush}"/>
+                    </Trigger>
+                    <Trigger Property="IsPressed" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -61,12 +60,13 @@
             <!-- Primary button -->
             <Style x:Key="PrimaryButtonStyle" TargetType="Button">
                 <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource PrimaryButtonBorderBrush}"/>
-                <Setter Property="BorderThickness" Value="0.9"/>
+                <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Padding" Value="6,2"/>
-                <Setter Property="FontSize" Value="14"/>
+                <Setter Property="FontSize" Value="15"/>
                 <Setter Property="Margin" Value="4"/>
+                <Setter Property="FontFamily" Value="Segoe UI"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
@@ -74,7 +74,7 @@
                                     Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="2">
+                                    CornerRadius="8">
                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
                             <ControlTemplate.Triggers>
@@ -83,6 +83,7 @@
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter TargetName="ButtonBorder" Property="Background" Value="{DynamicResource DisabledButtonBackgroundBrush}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -92,20 +93,21 @@
 
             <!-- Secondary button -->
             <Style x:Key="SecondaryButtonStyle" TargetType="Button">
-                <Setter Property="Background" Value="{StaticResource SecondaryBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="BorderBrush" Value="{StaticResource SecondaryVariantBrush}"/>
-                <Setter Property="BorderThickness" Value="0.7"/>
+                <Setter Property="Background" Value="{DynamicResource SecondaryButtonBackgroundBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnSecondaryBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource SecondaryVariantBrush}"/>
+                <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Padding" Value="6,2"/>
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="Margin" Value="4"/>
+                <Setter Property="FontFamily" Value="Segoe UI"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
                             <Border Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="2">
+                                    CornerRadius="8">
                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
                         </ControlTemplate>
@@ -113,61 +115,74 @@
                 </Setter>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="{StaticResource ButtonHoverHighlightBrush}"/>
+                        <Setter Property="Background" Value="{DynamicResource ButtonHoverHighlightBrush}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryButtonBorderBrush}"/>
+                    </Trigger>
+                    <Trigger Property="IsPressed" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryButtonBorderBrush}"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                        <Setter Property="Background" Value="{DynamicResource DisabledButtonBackgroundBrush}"/>
+                        <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource DisabledButtonBackgroundBrush}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <!-- TextBlock styles -->
             <Style x:Key="SectionHeaderTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="FontWeight" Value="Bold"/>
-                <Setter Property="FontSize" Value="18"/>
+                <Setter Property="Foreground" Value="{DynamicResource TitleTextBrush}"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="FontFamily" Value="Segoe UI"/>
             </Style>
             <Style x:Key="BodyTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource BodyTextBrush}"/>
                 <Setter Property="FontSize" Value="14"/>
+                <Setter Property="FontFamily" Value="Segoe UI"/>
             </Style>
 
             <!-- Window, panels -->
             <Style TargetType="Window">
-                <Setter Property="Background" Value="{StaticResource BackgroundBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnBackgroundBrush}"/>
+                <Setter Property="FontFamily" Value="Segoe UI"/>
             </Style>
             <Style TargetType="StackPanel">
-                <Setter Property="Background" Value="{StaticResource SurfaceBrush}"/>
+                <Setter Property="Background" Value="Transparent"/>
             </Style>
             <Style TargetType="Grid">
-                <Setter Property="Background" Value="{StaticResource SurfaceBrush}"/>
+                <Setter Property="Background" Value="Transparent"/>
             </Style>
 
             <!-- TextBox -->
             <Style TargetType="TextBox">
-                <Setter Property="Background" Value="{StaticResource BackgroundBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="BorderBrush" Value="{StaticResource PrimaryVariantBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnSurfaceBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PrimaryVariantBrush}"/>
             </Style>
 
             <!-- ListBox -->
             <Style TargetType="ListBox">
-                <Setter Property="Background" Value="{StaticResource SurfaceBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="BorderBrush" Value="{StaticResource PrimaryVariantBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnSurfaceBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PrimaryVariantBrush}"/>
             </Style>
 
             <!-- ComboBox -->
             <Style TargetType="ComboBox">
-                <Setter Property="Background" Value="{StaticResource BackgroundBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="BorderBrush" Value="{StaticResource PrimaryVariantBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnSurfaceBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PrimaryVariantBrush}"/>
                 <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="Padding" Value="4,2"/>
             </Style>
 
             <!-- ComboBoxItem with custom template -->
             <Style TargetType="ComboBoxItem">
-                <Setter Property="Background" Value="#0d162b"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnSurfaceBrush}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="ComboBoxItem">
@@ -179,11 +194,15 @@
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource ButtonHoverHighlightBrush}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ButtonHoverHighlightBrush}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource ButtonHoverHighlightBrush}"/>
-                                    <Setter Property="Foreground" Value="White"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/ClockifyUtility/App.xaml
+++ b/ClockifyUtility/App.xaml
@@ -13,7 +13,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!-- System highlight overrides (MUST precede usage) -->
-            <Color x:Key="{x:Static SystemColors.HighlightColorKey}">#1d4ed8</Color>
+            <Color x:Key="{x:Static SystemColors.HighlightColorKey}">#1F6FEB</Color>
             <Color x:Key="{x:Static SystemColors.HighlightTextColorKey}">#FFFFFF</Color>
 
             <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"/>

--- a/ClockifyUtility/App.xaml
+++ b/ClockifyUtility/App.xaml
@@ -135,7 +135,7 @@
                 <Setter Property="Background" Value="{DynamicResource SurfaceAccentBrush}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
                 <Setter Property="BorderThickness" Value="1"/>
-                <Setter Property="Padding" Value="10,8"/>
+                <Setter Property="Padding" Value="10,6"/>
                 <Setter Property="FontFamily" Value="Segoe UI"/>
                 <Setter Property="Foreground" Value="{DynamicResource BodyTextBrush}"/>
                 <Setter Property="Cursor" Value="Hand"/>
@@ -146,7 +146,7 @@
                                     Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="10"
+                                    CornerRadius="8"
                                     SnapsToDevicePixels="True">
                                 <ContentPresenter Margin="0"
                                                   HorizontalAlignment="Stretch"

--- a/ClockifyUtility/App.xaml
+++ b/ClockifyUtility/App.xaml
@@ -13,7 +13,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!-- System highlight overrides (MUST precede usage) -->
-            <Color x:Key="{x:Static SystemColors.HighlightColorKey}">#1e3a8a</Color>
+            <Color x:Key="{x:Static SystemColors.HighlightColorKey}">#1d4ed8</Color>
             <Color x:Key="{x:Static SystemColors.HighlightTextColorKey}">#FFFFFF</Color>
 
             <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"/>
@@ -128,6 +128,46 @@
                         <Setter Property="BorderBrush" Value="{DynamicResource DisabledButtonBackgroundBrush}"/>
                     </Trigger>
                 </Style.Triggers>
+            </Style>
+
+            <!-- Theme radio buttons -->
+            <Style x:Key="ThemeOptionRadioButtonStyle" TargetType="RadioButton">
+                <Setter Property="Background" Value="{DynamicResource SurfaceAccentBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Padding" Value="10,8"/>
+                <Setter Property="FontFamily" Value="Segoe UI"/>
+                <Setter Property="Foreground" Value="{DynamicResource BodyTextBrush}"/>
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Border"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="10"
+                                    SnapsToDevicePixels="True">
+                                <ContentPresenter Margin="0"
+                                                  HorizontalAlignment="Stretch"
+                                                  VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Border" Property="Background" Value="{DynamicResource SelectorBoxBrush}"/>
+                                </Trigger>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Border" Property="Background" Value="{DynamicResource PrimaryBrush}"/>
+                                    <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource PrimaryBrush}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="Border" Property="Opacity" Value="0.6"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
 
             <!-- TextBlock styles -->

--- a/ClockifyUtility/App.xaml.cs
+++ b/ClockifyUtility/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 
 using ClockifyUtility.Services;
+using ClockifyUtility.Helpers;
 using ClockifyUtility.ViewModels;
 
 /// <summary>
@@ -15,9 +16,11 @@ public partial class App : Application
 	private static bool _serilogInitialized = false;
 	public static ServiceProvider? ServiceProvider { get; private set; }
 
-	protected override void OnStartup ( StartupEventArgs e )
-	{
-		// Step 4: Load and validate all invoice configs at startup
+        protected override void OnStartup ( StartupEventArgs e )
+        {
+                ThemeManager.Initialize(this);
+
+                // Step 4: Load and validate all invoice configs at startup
 	   string exeDir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) ?? string.Empty;
 	   string appSettingsPath = System.IO.Path.Combine(exeDir, "appsettings.json");
 	   string? invoiceConfigDir = null;

--- a/ClockifyUtility/Colors.xaml
+++ b/ClockifyUtility/Colors.xaml
@@ -2,27 +2,27 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Primary and Secondary Colors -->
-    <Color x:Key="PrimaryColor">#FF1F6FEB</Color>
-    <Color x:Key="PrimaryVariantColor">#FF0F3DBD</Color>
-    <Color x:Key="SecondaryColor">#FF3AA0F3</Color>
-    <Color x:Key="SecondaryVariantColor">#FF114199</Color>
+    <Color x:Key="PrimaryColor">#FF3A6DDA</Color>
+    <Color x:Key="PrimaryVariantColor">#FF244EB7</Color>
+    <Color x:Key="SecondaryColor">#FF2F82D9</Color>
+    <Color x:Key="SecondaryVariantColor">#FF1D4E99</Color>
 
     <!-- Backgrounds and Surfaces -->
-    <Color x:Key="BackgroundColor">#FFF1F6FF</Color>
+    <Color x:Key="BackgroundColor">#FFF2F5FB</Color>
     <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
-    <Color x:Key="SelectorBoxColor">#FFCFE2FF</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FFDCEAFF</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FFC3D4EE</Color>
+    <Color x:Key="SelectorBoxColor">#FFD8E3F7</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FFE1E9F7</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FFC7D2E6</Color>
 
     <!-- Error and Highlight -->
-    <Color x:Key="ErrorColor">#FFE44F61</Color>
-    <Color x:Key="HighlightColor">#FF3E8BFF</Color>
+    <Color x:Key="ErrorColor">#FFE56A76</Color>
+    <Color x:Key="HighlightColor">#FF4A89F5</Color>
 
     <!-- On Colors (text/icons on colored backgrounds) -->
     <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
-    <Color x:Key="OnSecondaryColor">#FF183056</Color>
-    <Color x:Key="OnBackgroundColor">#FF12213B</Color>
-    <Color x:Key="OnSurfaceColor">#FF1D2E4B</Color>
+    <Color x:Key="OnSecondaryColor">#FF1F2F4A</Color>
+    <Color x:Key="OnBackgroundColor">#FF122038</Color>
+    <Color x:Key="OnSurfaceColor">#FF1A2C4C</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -39,11 +39,11 @@
     <SolidColorBrush x:Key="OnBackgroundBrush" Color="{StaticResource OnBackgroundColor}"/>
     <SolidColorBrush x:Key="OnSurfaceBrush" Color="{StaticResource OnSurfaceColor}"/>
     <SolidColorBrush x:Key="WhiteBrush" Color="#FFFFFFFF"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF3E8BFF"/>
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF3AA0F3"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF1F6FEB"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF0F3DBD"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1857D6"/>
-    <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="#FFDCEAFF"/>
-    <SolidColorBrush x:Key="DisabledButtonBackgroundBrush" Color="#FFC3D4EE"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF4A89F5"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF2F82D9"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF3A6DDA"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF244EB7"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF2F5FCF"/>
+    <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="#FFE1E9F7"/>
+    <SolidColorBrush x:Key="DisabledButtonBackgroundBrush" Color="#FFC7D2E6"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Colors.xaml
+++ b/ClockifyUtility/Colors.xaml
@@ -1,28 +1,28 @@
-<!-- Colors.xaml: Central color palette for the application -->
+<!-- Colors.xaml: Legacy palette references kept in sync with active theme hues -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Primary and Secondary Colors -->
-    <Color x:Key="PrimaryColor">#FF122b61</Color> <!-- Custom Button Blue -->
-    <Color x:Key="PrimaryVariantColor">#FF16b7d5</Color> <!-- Custom Border Color -->
-    <Color x:Key="SecondaryColor">#FF122b61</Color>
-    <Color x:Key="SecondaryVariantColor">#FF16b7d5</Color>
+    <Color x:Key="PrimaryColor">#FF1F6FEB</Color>
+    <Color x:Key="PrimaryVariantColor">#FF0F3DBD</Color>
+    <Color x:Key="SecondaryColor">#FF3AA0F3</Color>
+    <Color x:Key="SecondaryVariantColor">#FF114199</Color>
 
     <!-- Backgrounds and Surfaces -->
-    <Color x:Key="BackgroundColor">#FF0d162b</Color>
-    <Color x:Key="SurfaceColor">#FF122b61</Color>
-    <Color x:Key="SelectorBoxColor">#FF0e224e</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FF0b1a3d</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FF3e5791</Color>
+    <Color x:Key="BackgroundColor">#FFF1F6FF</Color>
+    <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
+    <Color x:Key="SelectorBoxColor">#FFCFE2FF</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FFDCEAFF</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FFC3D4EE</Color>
 
     <!-- Error and Highlight -->
-    <Color x:Key="ErrorColor">#FFD32F2F</Color>
-    <Color x:Key="HighlightColor">#FFB3E5FC</Color> <!-- Light Blue -->
+    <Color x:Key="ErrorColor">#FFE44F61</Color>
+    <Color x:Key="HighlightColor">#FF3E8BFF</Color>
 
     <!-- On Colors (text/icons on colored backgrounds) -->
     <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
-    <Color x:Key="OnSecondaryColor">#FFFFFFFF</Color>
-    <Color x:Key="OnBackgroundColor">#FFFFFFFF</Color>
-    <Color x:Key="OnSurfaceColor">#FFFFFFFF</Color>
+    <Color x:Key="OnSecondaryColor">#FF183056</Color>
+    <Color x:Key="OnBackgroundColor">#FF12213B</Color>
+    <Color x:Key="OnSurfaceColor">#FF1D2E4B</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -38,13 +38,12 @@
     <SolidColorBrush x:Key="OnSecondaryBrush" Color="{StaticResource OnSecondaryColor}"/>
     <SolidColorBrush x:Key="OnBackgroundBrush" Color="{StaticResource OnBackgroundColor}"/>
     <SolidColorBrush x:Key="OnSurfaceBrush" Color="{StaticResource OnSurfaceColor}"/>
-    <SolidColorBrush x:Key="WhiteBrush" Color="#FFFFFFFF"/> <!-- Pure white brush for foregrounds -->
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#1e3e83"/>
-    <!-- Custom ComboBox Focus Border Brush (white for testing) -->
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FFFFFFFF"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#0e224e"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#1e408c"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#204291"/>
-    <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="#0b1a3d"/>
-    <SolidColorBrush x:Key="DisabledButtonBackgroundBrush" Color="#3e5791"/>
+    <SolidColorBrush x:Key="WhiteBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF3E8BFF"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF3AA0F3"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF1F6FEB"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF0F3DBD"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1857D6"/>
+    <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="#FFDCEAFF"/>
+    <SolidColorBrush x:Key="DisabledButtonBackgroundBrush" Color="#FFC3D4EE"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Helpers/ThemeManager.cs
+++ b/ClockifyUtility/Helpers/ThemeManager.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using System.Windows;
+using Microsoft.Win32;
+
+namespace ClockifyUtility.Helpers;
+
+public enum AppTheme
+{
+        System,
+        Light,
+        Dark
+}
+
+public sealed class ThemeChangedEventArgs : EventArgs
+{
+        public ThemeChangedEventArgs(AppTheme requestedTheme, AppTheme effectiveTheme)
+        {
+                RequestedTheme = requestedTheme;
+                EffectiveTheme = effectiveTheme;
+        }
+
+        public AppTheme RequestedTheme { get; }
+
+        public AppTheme EffectiveTheme { get; }
+}
+
+public static class ThemeManager
+{
+        private const string SettingsFileName = "theme-preferences.json";
+        private static readonly string SettingsDirectory = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "ClockifyUtility");
+        private static readonly string SettingsPath = System.IO.Path.Combine(SettingsDirectory, SettingsFileName);
+
+        private static ResourceDictionary? _currentThemeDictionary;
+        private static AppTheme _requestedTheme = AppTheme.System;
+
+        public static event EventHandler<ThemeChangedEventArgs>? ThemeChanged;
+
+        public static AppTheme RequestedTheme => _requestedTheme;
+
+        public static AppTheme EffectiveTheme { get; private set; } = AppTheme.System;
+
+        public static void Initialize(Application application)
+        {
+                var savedTheme = LoadPreference();
+                ApplyTheme(application, savedTheme, persist: false);
+        }
+
+        public static AppTheme CycleTheme(Application application)
+        {
+                var next = _requestedTheme switch
+                {
+                        AppTheme.System => AppTheme.Light,
+                        AppTheme.Light => AppTheme.Dark,
+                        _ => AppTheme.System,
+                };
+
+                ApplyTheme(application, next);
+                return next;
+        }
+
+        public static void ApplyTheme(Application application, AppTheme theme, bool persist = true)
+        {
+                _requestedTheme = theme;
+                var effectiveTheme = theme == AppTheme.System ? GetSystemTheme() : theme;
+
+                var dictionaries = application.Resources.MergedDictionaries;
+                if (_currentThemeDictionary != null)
+                {
+                        dictionaries.Remove(_currentThemeDictionary);
+                }
+
+                _currentThemeDictionary = CreateThemeDictionary(effectiveTheme);
+                dictionaries.Insert(0, _currentThemeDictionary);
+                EffectiveTheme = effectiveTheme;
+
+                if (persist)
+                {
+                        SavePreference(theme);
+                }
+
+                ThemeChanged?.Invoke(application, new ThemeChangedEventArgs(theme, effectiveTheme));
+        }
+
+        private static ResourceDictionary CreateThemeDictionary(AppTheme theme)
+        {
+                var uri = theme switch
+                {
+                        AppTheme.Light => new Uri("/ClockifyUtility;component/Themes/Theme.Light.xaml", UriKind.Relative),
+                        _ => new Uri("/ClockifyUtility;component/Themes/Theme.Dark.xaml", UriKind.Relative)
+                };
+
+                return new ResourceDictionary { Source = uri };
+        }
+
+        private static AppTheme LoadPreference()
+        {
+                try
+                {
+                        if (System.IO.File.Exists(SettingsPath))
+                        {
+                                var json = System.IO.File.ReadAllText(SettingsPath);
+                                var preference = JsonSerializer.Deserialize<ThemePreference>(json);
+                                if (preference != null && Enum.TryParse(preference.RequestedTheme, out AppTheme parsed))
+                                {
+                                        return parsed;
+                                }
+                        }
+                }
+                catch
+                {
+                        // Ignore preference load failures and fall back to system theme
+                }
+
+                return AppTheme.System;
+        }
+
+        private static void SavePreference(AppTheme theme)
+        {
+                try
+                {
+                        if (!System.IO.Directory.Exists(SettingsDirectory))
+                        {
+                                _ = System.IO.Directory.CreateDirectory(SettingsDirectory);
+                        }
+
+                        var json = JsonSerializer.Serialize(new ThemePreference(theme.ToString()));
+                        System.IO.File.WriteAllText(SettingsPath, json);
+                }
+                catch
+                {
+                        // Ignore persistence failures; app can operate without stored preferences
+                }
+        }
+
+        private static AppTheme GetSystemTheme()
+        {
+                try
+                {
+                        object? value = Registry.GetValue(
+                                @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+                                "AppsUseLightTheme",
+                                null);
+                        if (value is int intValue)
+                        {
+                                return intValue > 0 ? AppTheme.Light : AppTheme.Dark;
+                        }
+                }
+                catch
+                {
+                        // Ignore registry access errors and fall back to light theme
+                }
+
+                return AppTheme.Light;
+        }
+
+        private sealed record ThemePreference(string RequestedTheme);
+}

--- a/ClockifyUtility/Helpers/ThemeManager.cs
+++ b/ClockifyUtility/Helpers/ThemeManager.cs
@@ -47,19 +47,6 @@ public static class ThemeManager
                 ApplyTheme(application, savedTheme, persist: false);
         }
 
-        public static AppTheme CycleTheme(Application application)
-        {
-                var next = _requestedTheme switch
-                {
-                        AppTheme.System => AppTheme.Light,
-                        AppTheme.Light => AppTheme.Dark,
-                        _ => AppTheme.System,
-                };
-
-                ApplyTheme(application, next);
-                return next;
-        }
-
         public static void ApplyTheme(Application application, AppTheme theme, bool persist = true)
         {
                 _requestedTheme = theme;

--- a/ClockifyUtility/MainWindow.xaml
+++ b/ClockifyUtility/MainWindow.xaml
@@ -18,62 +18,179 @@
 
         <Border Grid.Row="0"
                 Background="{DynamicResource HeaderGradientBrush}"
-                Padding="28,20"
+                Padding="28,24"
                 SnapsToDevicePixels="True">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Image Source="pack://application:,,,/Assets/ClockifyUtilityLogoSmaller.PNG"
-                           Height="42"
-                           Margin="0,0,14,0"
-                           Stretch="Uniform"/>
-                    <StackPanel>
-                        <TextBlock Text="Clockify Utility"
-                                   FontSize="20"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource OnPrimaryBrush}"/>
-                        <TextBlock Text="Keep your Clockify projects invoiced and on-brand"
-                                   Margin="0,4,0,0"
-                                   FontSize="13"
-                                   Foreground="{DynamicResource OnSecondaryBrush}"/>
-                    </StackPanel>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Orientation="Vertical"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="Clockify Utility"
+                               FontSize="24"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource OnPrimaryBrush}"/>
+                    <TextBlock Text="Create polished invoices with confidence"
+                               Margin="0,6,0,0"
+                               FontSize="13"
+                               Foreground="{DynamicResource OnSecondaryBrush}"/>
                 </StackPanel>
 
-                <Button x:Name="ThemeToggleButton"
-                        DockPanel.Dock="Right"
-                        Margin="16,0,0,0"
-                        Padding="14,6"
-                        Style="{StaticResource SecondaryButtonStyle}"
-                        Click="ThemeToggleButton_Click"
-                        ToolTip="Click to cycle through system, light, and dark themes">
+                <Border Grid.Column="1"
+                        Background="{DynamicResource SurfaceBrush}"
+                        BorderBrush="{DynamicResource CardBorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="14"
+                        Padding="14,10"
+                        Margin="24,0,0,0"
+                        VerticalAlignment="Center">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock x:Name="ThemeIcon"
-                                   FontFamily="{StaticResource FontAwesomeSolid}"
-                                   FontSize="14"
-                                   Margin="0,0,6,0"
-                                   VerticalAlignment="Center"
-                                   Foreground="{DynamicResource OnSecondaryBrush}"/>
-                        <TextBlock x:Name="ThemeLabel"
-                                   FontSize="14"
-                                   VerticalAlignment="Center"
-                                   Foreground="{DynamicResource OnSecondaryBrush}"/>
+                        <RadioButton x:Name="SystemThemeRadio"
+                                     Margin="0,0,8,0"
+                                     Width="120"
+                                     Style="{StaticResource ThemeOptionRadioButtonStyle}"
+                                     GroupName="ThemeModes"
+                                     Tag="System"
+                                     Checked="ThemeOptionRadioButton_Checked"
+                                     ToolTip="Follow the Windows theme">
+                            <RadioButton.Content>
+                                <StackPanel>
+                                    <TextBlock Text="System"
+                                               FontSize="13"
+                                               FontWeight="SemiBold">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource BodyTextBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock x:Name="SystemThemeDetailText"
+                                               Text="Matches OS"
+                                               Margin="0,2,0,0"
+                                               FontSize="11">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                                        <Setter Property="Opacity" Value="0.85"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </RadioButton.Content>
+                        </RadioButton>
+                        <RadioButton x:Name="LightThemeRadio"
+                                     Margin="0,0,8,0"
+                                     Width="100"
+                                     Style="{StaticResource ThemeOptionRadioButtonStyle}"
+                                     GroupName="ThemeModes"
+                                     Tag="Light"
+                                     Checked="ThemeOptionRadioButton_Checked"
+                                     ToolTip="Switch to the light theme">
+                            <RadioButton.Content>
+                                <StackPanel>
+                                    <TextBlock Text="Light"
+                                               FontSize="13"
+                                               FontWeight="SemiBold">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource BodyTextBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Text="Soft &amp; airy"
+                                               Margin="0,2,0,0"
+                                               FontSize="11">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                                        <Setter Property="Opacity" Value="0.85"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </RadioButton.Content>
+                        </RadioButton>
+                        <RadioButton x:Name="DarkThemeRadio"
+                                     Width="100"
+                                     Style="{StaticResource ThemeOptionRadioButtonStyle}"
+                                     GroupName="ThemeModes"
+                                     Tag="Dark"
+                                     Checked="ThemeOptionRadioButton_Checked"
+                                     ToolTip="Switch to the dark theme">
+                            <RadioButton.Content>
+                                <StackPanel>
+                                    <TextBlock Text="Dark"
+                                               FontSize="13"
+                                               FontWeight="SemiBold">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource BodyTextBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Text="Focused &amp; calm"
+                                               Margin="0,2,0,0"
+                                               FontSize="11">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                                        <Setter Property="Opacity" Value="0.85"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </RadioButton.Content>
+                        </RadioButton>
                     </StackPanel>
-                </Button>
-            </DockPanel>
+                </Border>
+            </Grid>
         </Border>
 
         <Grid Grid.Row="1" Margin="32">
             <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource CardBorderBrush}"
                     BorderThickness="1"
-                    CornerRadius="18"
-                    Padding="32"
-                    MaxWidth="540"
+                    CornerRadius="22"
+                    Padding="36"
+                    MaxWidth="560"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center">
                 <Border.Effect>
-                    <DropShadowEffect BlurRadius="22"
+                    <DropShadowEffect BlurRadius="26"
                                       ShadowDepth="0"
-                                      Opacity="0.35"
+                                      Opacity="0.32"
                                       Color="{Binding Color, Source={StaticResource SurfaceShadowBrush}}"/>
                 </Border.Effect>
                 <Grid>
@@ -101,7 +218,7 @@
                     <Border Grid.Row="2"
                             Background="{DynamicResource SurfaceAccentBrush}"
                             Padding="18,12"
-                            CornerRadius="12"
+                            CornerRadius="14"
                             SnapsToDevicePixels="True">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -179,9 +296,9 @@
                     </StackPanel>
 
                     <Button Grid.Row="5"
-                            Margin="0,28,0,0"
+                            Margin="0,30,0,0"
                             Width="260"
-                            Height="40"
+                            Height="42"
                             Command="{Binding GenerateInvoiceCommand}"
                             Content="{Binding GenerateButtonText}"
                             IsEnabled="{Binding IsGenerateButtonEnabled}"

--- a/ClockifyUtility/MainWindow.xaml
+++ b/ClockifyUtility/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="ClockifyUtility.MainWindow"
+<Window x:Class="ClockifyUtility.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -6,96 +6,191 @@
         xmlns:local="clr-namespace:ClockifyUtility"
         xmlns:controls="clr-namespace:ClockifyUtility.Controls"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800"
+        Title="Clockify Utility"
+        Height="540"
+        Width="920"
         WindowStartupLocation="CenterScreen">
-    <Grid Background="{StaticResource BackgroundBrush}">
-        <Image Source="pack://application:,,,/Assets/ClockifyUtilityLogoSmaller.PNG"
-               Margin="6"
-               HorizontalAlignment="Left"
-               VerticalAlignment="Top"
-               Stretch="Uniform"
-               Height="64"/>
-        <Border Background="{StaticResource SurfaceBrush}"
-                Padding="32"
-                CornerRadius="3"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
+    <Grid Background="{DynamicResource BackgroundBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Background="{DynamicResource HeaderGradientBrush}"
+                Padding="28,20"
                 SnapsToDevicePixels="True">
-            <StackPanel>
-
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,10">
-                    <Button x:Name="btnPreviousMonth"
-                            Style="{StaticResource MonthSelectorButtonStyle}"
-                            Content="&#xF272;"
-                            Margin="0,0,10,0"
-                            Command="{Binding PreviousMonthCommand}"
-                            ToolTip="Previous month"
-                            AutomationProperties.Name="Previous month" />
-
-                    <TextBlock x:Name="lblCurrentMonth"
-                               Text="{Binding CurrentMonthLabel}"
-                               Style="{StaticResource SectionHeaderTextBlockStyle}"
-                               VerticalAlignment="Center"
-                               Width="120"
-                               TextAlignment="Center" FontFamily="Nirmala UI Semilight" />
-
-                    <Button x:Name="btnNextMonth"
-                            Style="{StaticResource MonthSelectorButtonStyle}"
-                            Content="&#xF271;"
-                            Margin="10,0,0,0"
-                            Command="{Binding NextMonthCommand}"
-                            ToolTip="Next month"
-                            AutomationProperties.Name="Next month" />
+            <DockPanel LastChildFill="False">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <Image Source="pack://application:,,,/Assets/ClockifyUtilityLogoSmaller.PNG"
+                           Height="42"
+                           Margin="0,0,14,0"
+                           Stretch="Uniform"/>
+                    <StackPanel>
+                        <TextBlock Text="Clockify Utility"
+                                   FontSize="20"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource OnPrimaryBrush}"/>
+                        <TextBlock Text="Keep your Clockify projects invoiced and on-brand"
+                                   Margin="0,4,0,0"
+                                   FontSize="13"
+                                   Foreground="{DynamicResource OnSecondaryBrush}"/>
+                    </StackPanel>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,10">
-                    <controls:PaletteComboBox Width="300"
-                                              Height="30"
-                                              Margin="0,0,10,0"
-                                              Padding="6,0,2,0"
-                                              FontSize="13"
-                                              VerticalContentAlignment="Center"
-                                              HorizontalContentAlignment="Left"
-                                              Foreground="{StaticResource WhiteBrush}"
-                                              KeyboardNavigation.TabNavigation="Local"
-                                              ItemsSource="{Binding DisplayInvoiceConfigs}"
-                                              SelectedItem="{Binding SelectedInvoiceConfig, Mode=TwoWay}"
-                                              BorderBrush="{DynamicResource PrimaryButtonBorderBrush}"
-                                              Background="{DynamicResource PrimaryButtonBackgroundBrush}"
-                                              FontFamily="Nirmala UI Semilight" />
-
-                    <Button Style="{StaticResource MonthSelectorButtonStyle}"
-                            Width="16"
-                            Height="16"
-                            Margin="6,6,0,6"
-                            Padding="0"
-                            Focusable="False"
-                            Command="{Binding SetDefaultInvoiceCommand}"
-                            ToolTip="Set as default"
-                            AutomationProperties.Name="Set as default"
-                            VerticalAlignment="Center">
-                        <TextBlock FontSize="10"
+                <Button x:Name="ThemeToggleButton"
+                        DockPanel.Dock="Right"
+                        Margin="16,0,0,0"
+                        Padding="14,6"
+                        Style="{StaticResource SecondaryButtonStyle}"
+                        Click="ThemeToggleButton_Click"
+                        ToolTip="Click to cycle through system, light, and dark themes">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock x:Name="ThemeIcon"
+                                   FontFamily="{StaticResource FontAwesomeSolid}"
+                                   FontSize="14"
+                                   Margin="0,0,6,0"
                                    VerticalAlignment="Center"
-                                   HorizontalAlignment="Center"
-                                   Text="{Binding StarIconUnicode}"
-                                   FontFamily="{Binding StarIconFontFamily}" />
-                    </Button>
-                </StackPanel>
-
-                <Button Width="220"
-                        Height="30"
-                        Command="{Binding GenerateInvoiceCommand}"
-                        Content="{Binding GenerateButtonText}"
-                        IsEnabled="{Binding IsGenerateButtonEnabled}"
-                        Style="{StaticResource PrimaryButtonStyle}"
-                        HorizontalContentAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        BorderBrush="{DynamicResource PrimaryButtonBorderBrush}"
-                        Background="{DynamicResource PrimaryButtonBackgroundBrush}"
-                        FontSize="{Binding GenerateButtonFontSize}"
-                        FontFamily="Nirmala UI Semilight" />
-
-            </StackPanel>
+                                   Foreground="{DynamicResource OnSecondaryBrush}"/>
+                        <TextBlock x:Name="ThemeLabel"
+                                   FontSize="14"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource OnSecondaryBrush}"/>
+                    </StackPanel>
+                </Button>
+            </DockPanel>
         </Border>
+
+        <Grid Grid.Row="1" Margin="32">
+            <Border Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource CardBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="18"
+                    Padding="32"
+                    MaxWidth="540"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                <Border.Effect>
+                    <DropShadowEffect BlurRadius="22"
+                                      ShadowDepth="0"
+                                      Opacity="0.35"
+                                      Color="{Binding Color, Source={StaticResource SurfaceShadowBrush}}"/>
+                </Border.Effect>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               Text="Generate your Clockify invoice"
+                               FontSize="26"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource TitleTextBrush}"/>
+
+                    <TextBlock Grid.Row="1"
+                               Text="Select the billing period and configuration to create a polished PDF invoice in seconds."
+                               TextWrapping="Wrap"
+                               Margin="0,10,0,18"
+                               Foreground="{DynamicResource BodyTextBrush}"/>
+
+                    <Border Grid.Row="2"
+                            Background="{DynamicResource SurfaceAccentBrush}"
+                            Padding="18,12"
+                            CornerRadius="12"
+                            SnapsToDevicePixels="True">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Button x:Name="btnPreviousMonth"
+                                    Style="{StaticResource MonthSelectorButtonStyle}"
+                                    Content="&#xF272;"
+                                    Command="{Binding PreviousMonthCommand}"
+                                    ToolTip="Previous month"
+                                    AutomationProperties.Name="Previous month"/>
+
+                            <StackPanel Grid.Column="1"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Margin="20,0"
+                                        Orientation="Vertical">
+                                <TextBlock Text="Billing period"
+                                           FontSize="12"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SecondaryTextBrush}"/>
+                                <TextBlock x:Name="lblCurrentMonth"
+                                           Text="{Binding CurrentMonthLabel}"
+                                           FontSize="20"
+                                           FontWeight="SemiBold"
+                                           HorizontalAlignment="Center"
+                                           Foreground="{DynamicResource TitleTextBrush}"/>
+                            </StackPanel>
+
+                            <Button x:Name="btnNextMonth"
+                                    Grid.Column="2"
+                                    Style="{StaticResource MonthSelectorButtonStyle}"
+                                    Content="&#xF271;"
+                                    Command="{Binding NextMonthCommand}"
+                                    ToolTip="Next month"
+                                    AutomationProperties.Name="Next month"/>
+                        </Grid>
+                    </Border>
+
+                    <TextBlock Grid.Row="3"
+                               Margin="0,24,0,6"
+                               Text="Invoice configuration"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource SecondaryTextBrush}"/>
+
+                    <StackPanel Grid.Row="4" Orientation="Horizontal">
+                        <controls:PaletteComboBox Width="320"
+                                                  Height="34"
+                                                  Padding="8,0,2,0"
+                                                  FontSize="14"
+                                                  VerticalContentAlignment="Center"
+                                                  HorizontalContentAlignment="Left"
+                                                  ItemsSource="{Binding DisplayInvoiceConfigs}"
+                                                  SelectedItem="{Binding SelectedInvoiceConfig, Mode=TwoWay}"/>
+
+                        <Button Style="{StaticResource SecondaryButtonStyle}"
+                                Width="44"
+                                Height="34"
+                                Margin="12,0,0,0"
+                                Padding="0"
+                                Focusable="False"
+                                Command="{Binding SetDefaultInvoiceCommand}"
+                                ToolTip="Set as default"
+                                AutomationProperties.Name="Set as default">
+                            <TextBlock FontSize="14"
+                                       VerticalAlignment="Center"
+                                       HorizontalAlignment="Center"
+                                       Text="{Binding StarIconUnicode}"
+                                       FontFamily="{Binding StarIconFontFamily}"/>
+                        </Button>
+                    </StackPanel>
+
+                    <Button Grid.Row="5"
+                            Margin="0,28,0,0"
+                            Width="260"
+                            Height="40"
+                            Command="{Binding GenerateInvoiceCommand}"
+                            Content="{Binding GenerateButtonText}"
+                            IsEnabled="{Binding IsGenerateButtonEnabled}"
+                            Style="{StaticResource PrimaryButtonStyle}"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            FontSize="{Binding GenerateButtonFontSize}"/>
+                </Grid>
+            </Border>
+        </Grid>
     </Grid>
 </Window>

--- a/ClockifyUtility/MainWindow.xaml
+++ b/ClockifyUtility/MainWindow.xaml
@@ -7,8 +7,8 @@
         xmlns:controls="clr-namespace:ClockifyUtility.Controls"
         mc:Ignorable="d"
         Title="Clockify Utility"
-        Height="540"
-        Width="920"
+        Height="520"
+        Width="880"
         WindowStartupLocation="CenterScreen">
     <Grid Background="{DynamicResource BackgroundBrush}">
         <Grid.RowDefinitions>
@@ -18,10 +18,11 @@
 
         <Border Grid.Row="0"
                 Background="{DynamicResource HeaderGradientBrush}"
-                Padding="28,24"
+                Padding="28,18"
                 SnapsToDevicePixels="True">
             <Grid>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
@@ -29,27 +30,30 @@
                 <StackPanel Orientation="Vertical"
                             VerticalAlignment="Center">
                     <TextBlock Text="Clockify Utility"
-                               FontSize="24"
+                               FontSize="20"
                                FontWeight="SemiBold"
                                Foreground="{DynamicResource OnPrimaryBrush}"/>
                     <TextBlock Text="Create polished invoices with confidence"
-                               Margin="0,6,0,0"
-                               FontSize="13"
-                               Foreground="{DynamicResource OnSecondaryBrush}"/>
+                               Margin="0,4,0,0"
+                               FontSize="12"
+                               Foreground="{DynamicResource OnPrimaryBrush}"
+                               Opacity="0.78"/>
                 </StackPanel>
 
                 <Border Grid.Column="1"
+                        Width="16"/>
+
+                <Border Grid.Column="2"
                         Background="{DynamicResource SurfaceBrush}"
                         BorderBrush="{DynamicResource CardBorderBrush}"
                         BorderThickness="1"
-                        CornerRadius="14"
-                        Padding="14,10"
-                        Margin="24,0,0,0"
+                        CornerRadius="12"
+                        Padding="6"
                         VerticalAlignment="Center">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal"
+                                VerticalAlignment="Center">
                         <RadioButton x:Name="SystemThemeRadio"
-                                     Margin="0,0,8,0"
-                                     Width="120"
+                                     Margin="0,0,6,0"
                                      Style="{StaticResource ThemeOptionRadioButtonStyle}"
                                      GroupName="ThemeModes"
                                      Tag="System"
@@ -58,7 +62,7 @@
                             <RadioButton.Content>
                                 <StackPanel>
                                     <TextBlock Text="System"
-                                               FontSize="13"
+                                               FontSize="12"
                                                FontWeight="SemiBold">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
@@ -74,7 +78,7 @@
                                     <TextBlock x:Name="SystemThemeDetailText"
                                                Text="Matches OS"
                                                Margin="0,2,0,0"
-                                               FontSize="11">
+                                               FontSize="10">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
@@ -91,8 +95,7 @@
                             </RadioButton.Content>
                         </RadioButton>
                         <RadioButton x:Name="LightThemeRadio"
-                                     Margin="0,0,8,0"
-                                     Width="100"
+                                     Margin="0,0,6,0"
                                      Style="{StaticResource ThemeOptionRadioButtonStyle}"
                                      GroupName="ThemeModes"
                                      Tag="Light"
@@ -101,7 +104,7 @@
                             <RadioButton.Content>
                                 <StackPanel>
                                     <TextBlock Text="Light"
-                                               FontSize="13"
+                                               FontSize="12"
                                                FontWeight="SemiBold">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
@@ -116,7 +119,7 @@
                                     </TextBlock>
                                     <TextBlock Text="Soft &amp; airy"
                                                Margin="0,2,0,0"
-                                               FontSize="11">
+                                               FontSize="10">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
@@ -133,7 +136,6 @@
                             </RadioButton.Content>
                         </RadioButton>
                         <RadioButton x:Name="DarkThemeRadio"
-                                     Width="100"
                                      Style="{StaticResource ThemeOptionRadioButtonStyle}"
                                      GroupName="ThemeModes"
                                      Tag="Dark"
@@ -142,7 +144,7 @@
                             <RadioButton.Content>
                                 <StackPanel>
                                     <TextBlock Text="Dark"
-                                               FontSize="13"
+                                               FontSize="12"
                                                FontWeight="SemiBold">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
@@ -157,7 +159,7 @@
                                     </TextBlock>
                                     <TextBlock Text="Focused &amp; calm"
                                                Margin="0,2,0,0"
-                                               FontSize="11">
+                                               FontSize="10">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
@@ -178,47 +180,55 @@
             </Grid>
         </Border>
 
-        <Grid Grid.Row="1" Margin="32">
-            <Border Background="{DynamicResource SurfaceBrush}"
+        <Grid Grid.Row="1" Margin="36,28,36,36">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Margin="0,0,48,0"
+                        MaxWidth="320">
+                <Border Width="44"
+                        Height="3"
+                        CornerRadius="2"
+                        Background="{DynamicResource PrimaryBrush}"/>
+                <TextBlock Text="Generate your Clockify invoice"
+                           Margin="0,14,0,0"
+                           FontSize="28"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"
+                           Foreground="{DynamicResource TitleTextBrush}"/>
+                <TextBlock Text="Pick a billing period, choose your template, and export a clean PDF invoice in moments."
+                           Margin="0,12,0,0"
+                           TextWrapping="Wrap"
+                           Foreground="{DynamicResource BodyTextBrush}"/>
+            </StackPanel>
+
+            <Border Grid.Column="1"
+                    Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource CardBorderBrush}"
                     BorderThickness="1"
-                    CornerRadius="22"
-                    Padding="36"
-                    MaxWidth="560"
-                    HorizontalAlignment="Center"
+                    CornerRadius="18"
+                    Padding="28"
+                    MaxWidth="420"
                     VerticalAlignment="Center">
                 <Border.Effect>
-                    <DropShadowEffect BlurRadius="26"
+                    <DropShadowEffect BlurRadius="20"
                                       ShadowDepth="0"
-                                      Opacity="0.32"
+                                      Opacity="0.22"
                                       Color="{Binding Color, Source={StaticResource SurfaceShadowBrush}}"/>
                 </Border.Effect>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-
-                    <TextBlock Grid.Row="0"
-                               Text="Generate your Clockify invoice"
-                               FontSize="26"
+                <StackPanel>
+                    <TextBlock Text="Billing period"
+                               FontSize="12"
                                FontWeight="SemiBold"
-                               Foreground="{DynamicResource TitleTextBrush}"/>
-
-                    <TextBlock Grid.Row="1"
-                               Text="Select the billing period and configuration to create a polished PDF invoice in seconds."
-                               TextWrapping="Wrap"
-                               Margin="0,10,0,18"
-                               Foreground="{DynamicResource BodyTextBrush}"/>
-
-                    <Border Grid.Row="2"
-                            Background="{DynamicResource SurfaceAccentBrush}"
-                            Padding="18,12"
-                            CornerRadius="14"
+                               Foreground="{DynamicResource SecondaryTextBrush}"/>
+                    <Border Background="{DynamicResource SurfaceAccentBrush}"
+                            Margin="0,8,0,0"
+                            Padding="14,10"
+                            CornerRadius="12"
                             SnapsToDevicePixels="True">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -237,18 +247,19 @@
                             <StackPanel Grid.Column="1"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
-                                        Margin="20,0"
+                                        Margin="18,0"
                                         Orientation="Vertical">
-                                <TextBlock Text="Billing period"
-                                           FontSize="12"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource SecondaryTextBrush}"/>
                                 <TextBlock x:Name="lblCurrentMonth"
                                            Text="{Binding CurrentMonthLabel}"
                                            FontSize="20"
                                            FontWeight="SemiBold"
                                            HorizontalAlignment="Center"
                                            Foreground="{DynamicResource TitleTextBrush}"/>
+                                <TextBlock Text="Change period"
+                                           Margin="0,4,0,0"
+                                           FontSize="11"
+                                           HorizontalAlignment="Center"
+                                           Foreground="{DynamicResource SecondaryTextBrush}"/>
                             </StackPanel>
 
                             <Button x:Name="btnNextMonth"
@@ -261,14 +272,13 @@
                         </Grid>
                     </Border>
 
-                    <TextBlock Grid.Row="3"
-                               Margin="0,24,0,6"
+                    <TextBlock Margin="0,22,0,6"
                                Text="Invoice configuration"
                                FontSize="13"
                                FontWeight="SemiBold"
                                Foreground="{DynamicResource SecondaryTextBrush}"/>
 
-                    <StackPanel Grid.Row="4" Orientation="Horizontal">
+                    <StackPanel Orientation="Horizontal">
                         <controls:PaletteComboBox Width="320"
                                                   Height="34"
                                                   Padding="8,0,2,0"
@@ -295,10 +305,8 @@
                         </Button>
                     </StackPanel>
 
-                    <Button Grid.Row="5"
-                            Margin="0,30,0,0"
-                            Width="260"
-                            Height="42"
+                    <Button Margin="0,26,0,0"
+                            Height="44"
                             Command="{Binding GenerateInvoiceCommand}"
                             Content="{Binding GenerateButtonText}"
                             IsEnabled="{Binding IsGenerateButtonEnabled}"
@@ -306,7 +314,7 @@
                             HorizontalContentAlignment="Center"
                             VerticalContentAlignment="Center"
                             FontSize="{Binding GenerateButtonFontSize}"/>
-                </Grid>
+                </StackPanel>
             </Border>
         </Grid>
     </Grid>

--- a/ClockifyUtility/MainWindow.xaml.cs
+++ b/ClockifyUtility/MainWindow.xaml.cs
@@ -1,25 +1,72 @@
-﻿using System.Windows;
+using System.Windows;
 
-/// <summary>
-/// Interaction logic for MainWindow.xaml
-/// </summary>
+using ClockifyUtility.Helpers;
 using ClockifyUtility.ViewModels;
 
 namespace ClockifyUtility
 {
-	public partial class MainWindow : Window
-	{
-		public MainWindow()
-		{
-			InitializeComponent();
+        public partial class MainWindow : Window
+        {
+                public MainWindow()
+                {
+                        InitializeComponent();
 
-			// Use DI to resolve MainViewModel
-			MainViewModel? viewModel = App.ServiceProvider?.GetService(typeof(MainViewModel)) as MainViewModel;
-			if (viewModel == null)
-			{
-				throw new InvalidOperationException("MainViewModel could not be resolved from the service provider.");
-			}
-			DataContext = viewModel;
-		}
-	}
+                        // Use DI to resolve MainViewModel
+                        MainViewModel? viewModel = App.ServiceProvider?.GetService(typeof(MainViewModel)) as MainViewModel;
+                        if (viewModel == null)
+                        {
+                                throw new InvalidOperationException("MainViewModel could not be resolved from the service provider.");
+                        }
+                        DataContext = viewModel;
+
+                        ThemeManager.ThemeChanged += OnThemeManagerThemeChanged;
+                        UpdateThemeButton(ThemeManager.RequestedTheme, ThemeManager.EffectiveTheme);
+                }
+
+                private void ThemeToggleButton_Click(object sender, RoutedEventArgs e)
+                {
+                        ThemeManager.CycleTheme(Application.Current);
+                }
+
+                private void OnThemeManagerThemeChanged(object? sender, ThemeChangedEventArgs e)
+                {
+                        Dispatcher.Invoke(() => UpdateThemeButton(e.RequestedTheme, e.EffectiveTheme));
+                }
+
+                private void UpdateThemeButton(AppTheme requestedTheme, AppTheme effectiveTheme)
+                {
+                        if (ThemeIcon is null || ThemeLabel is null)
+                        {
+                                return;
+                        }
+
+                        string iconGlyph = requestedTheme switch
+                        {
+                                AppTheme.Light => "\uf185",
+                                AppTheme.Dark => "\uf186",
+                                _ => "\uf109"
+                        };
+
+                        string label = requestedTheme switch
+                        {
+                                AppTheme.Light => "Light",
+                                AppTheme.Dark => "Dark",
+                                _ => effectiveTheme switch
+                                {
+                                        AppTheme.Dark => "System · Dark",
+                                        AppTheme.Light => "System · Light",
+                                        _ => "System"
+                                }
+                        };
+
+                        ThemeIcon.Text = iconGlyph;
+                        ThemeLabel.Text = label;
+                }
+
+                protected override void OnClosed(EventArgs e)
+                {
+                        ThemeManager.ThemeChanged -= OnThemeManagerThemeChanged;
+                        base.OnClosed(e);
+                }
+        }
 }

--- a/ClockifyUtility/MainWindow.xaml.cs
+++ b/ClockifyUtility/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Windows;
+using System.Windows.Controls;
 
 using ClockifyUtility.Helpers;
 using ClockifyUtility.ViewModels;
@@ -20,47 +22,62 @@ namespace ClockifyUtility
                         DataContext = viewModel;
 
                         ThemeManager.ThemeChanged += OnThemeManagerThemeChanged;
-                        UpdateThemeButton(ThemeManager.RequestedTheme, ThemeManager.EffectiveTheme);
+                        UpdateThemeSelection(ThemeManager.RequestedTheme, ThemeManager.EffectiveTheme);
                 }
 
-                private void ThemeToggleButton_Click(object sender, RoutedEventArgs e)
-                {
-                        ThemeManager.CycleTheme(Application.Current);
-                }
+                private bool _isSynchronizingTheme;
 
                 private void OnThemeManagerThemeChanged(object? sender, ThemeChangedEventArgs e)
                 {
-                        Dispatcher.Invoke(() => UpdateThemeButton(e.RequestedTheme, e.EffectiveTheme));
+                        Dispatcher.Invoke(() => UpdateThemeSelection(e.RequestedTheme, e.EffectiveTheme));
                 }
 
-                private void UpdateThemeButton(AppTheme requestedTheme, AppTheme effectiveTheme)
+                private void ThemeOptionRadioButton_Checked(object sender, RoutedEventArgs e)
                 {
-                        if (ThemeIcon is null || ThemeLabel is null)
+                        if (_isSynchronizingTheme)
                         {
                                 return;
                         }
 
-                        string iconGlyph = requestedTheme switch
+                        if (sender is RadioButton radioButton && radioButton.IsChecked == true && radioButton.Tag is string tag && Enum.TryParse(tag, out AppTheme theme))
                         {
-                                AppTheme.Light => "\uf185",
-                                AppTheme.Dark => "\uf186",
-                                _ => "\uf109"
-                        };
+                                ThemeManager.ApplyTheme(Application.Current, theme);
+                        }
+                }
 
-                        string label = requestedTheme switch
+                private void UpdateThemeSelection(AppTheme requestedTheme, AppTheme effectiveTheme)
+                {
+                        if (SystemThemeRadio is null || LightThemeRadio is null || DarkThemeRadio is null)
                         {
-                                AppTheme.Light => "Light",
-                                AppTheme.Dark => "Dark",
-                                _ => effectiveTheme switch
+                                return;
+                        }
+
+                        _isSynchronizingTheme = true;
+
+                        try
+                        {
+                                SystemThemeRadio.IsChecked = requestedTheme == AppTheme.System;
+                                LightThemeRadio.IsChecked = requestedTheme == AppTheme.Light;
+                                DarkThemeRadio.IsChecked = requestedTheme == AppTheme.Dark;
+
+                                if (SystemThemeDetailText is not null)
                                 {
-                                        AppTheme.Dark => "System · Dark",
-                                        AppTheme.Light => "System · Light",
-                                        _ => "System"
-                                }
-                        };
+                                        string detail = requestedTheme == AppTheme.System
+                                                ? effectiveTheme switch
+                                                {
+                                                        AppTheme.Dark => "OS · Dark",
+                                                        AppTheme.Light => "OS · Light",
+                                                        _ => "Matches OS"
+                                                }
+                                                : "Matches OS";
 
-                        ThemeIcon.Text = iconGlyph;
-                        ThemeLabel.Text = label;
+                                        SystemThemeDetailText.Text = detail;
+                                }
+                        }
+                        finally
+                        {
+                                _isSynchronizingTheme = false;
+                        }
                 }
 
                 protected override void OnClosed(EventArgs e)

--- a/ClockifyUtility/Themes/CustomComboBox.xaml
+++ b/ClockifyUtility/Themes/CustomComboBox.xaml
@@ -6,7 +6,7 @@
     <local:SubtractValueConverter x:Key="SubtractValueConverter" />
 
     <Style x:Key="CustomComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Foreground" Value="{DynamicResource OnSurfaceBrush}"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Padding" Value="8,2,8,2"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
@@ -15,14 +15,14 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ButtonHoverHighlightBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ButtonHoverHighlightBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Foreground" Value="#FF888888"/>
+                <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -36,7 +36,7 @@
         <Setter Property="MinHeight" Value="30"/>
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryVariantBrush}"/>
-        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Foreground" Value="{DynamicResource OnSurfaceBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="6,0,2,0"/>
         <Setter Property="ItemContainerStyle" Value="{StaticResource CustomComboBoxItemStyle}"/>
@@ -84,7 +84,7 @@
                                     <Grid>
                                         <Path x:Name="Arrow"
                                               Data="M 0 0 L 6 8 L 12 0 Z"
-                                              Fill="White"
+                                              Fill="{DynamicResource OnSurfaceBrush}"
                                               Width="12" Height="8"
                                               HorizontalAlignment="Center"
                                               VerticalAlignment="Center"/>

--- a/ClockifyUtility/Themes/PaletteComboBox.xaml
+++ b/ClockifyUtility/Themes/PaletteComboBox.xaml
@@ -3,7 +3,7 @@
                     xmlns:local="clr-namespace:ClockifyUtility.Controls">
     <!-- ComboBoxItem style for dropdown items -->
     <Style x:Key="PaletteComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
         <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
         <Setter Property="FontSize" Value="11"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
@@ -27,15 +27,15 @@
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Bd" Property="Background" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
                             <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
-                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="Bd" Property="Background" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
                             <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
-                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="#FF888888"/>
+                            <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -55,7 +55,7 @@
                 <ControlTemplate TargetType="ToggleButton">
                     <Grid x:Name="ToggleGrid" Background="{TemplateBinding Background}">
                         <Path Data="M 0 0 L 8 8 L 16 0 Z"
-                              Fill="White"
+                              Fill="{DynamicResource OnPrimaryBrush}"
                               Width="16" Height="8"
                               HorizontalAlignment="Center"
                               VerticalAlignment="Center"/>
@@ -80,7 +80,7 @@
         <Setter Property="MinHeight" Value="30"/>
         <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryButtonBorderBrush}"/>
-        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="6,0,2,0"/>
         <Setter Property="ItemContainerStyle" Value="{StaticResource PaletteComboBoxItemStyle}"/>
@@ -154,8 +154,8 @@
                             <Setter TargetName="SelectedItemBackground" Property="CornerRadius" Value="0"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="Border" Property="Background" Value="#333"/>
-                            <Setter Property="Foreground" Value="#888"/>
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource DisabledButtonBackgroundBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
                             <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource PrimaryButtonHoverBrush}"/>

--- a/ClockifyUtility/Themes/Theme.Dark.xaml
+++ b/ClockifyUtility/Themes/Theme.Dark.xaml
@@ -1,26 +1,26 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Core palette -->
-    <Color x:Key="PrimaryColor">#FF2563EB</Color>
-    <Color x:Key="PrimaryVariantColor">#FF1E3A8A</Color>
-    <Color x:Key="SecondaryColor">#FF132A57</Color>
-    <Color x:Key="SecondaryVariantColor">#FF1E40AF</Color>
-    <Color x:Key="BackgroundStartColor">#FF050B19</Color>
-    <Color x:Key="BackgroundEndColor">#FF0F172A</Color>
-    <Color x:Key="SurfaceColor">#FF101D38</Color>
-    <Color x:Key="SurfaceAccentColor">#FF15264B</Color>
-    <Color x:Key="SelectorBoxColor">#FF1B2F57</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FF172A51</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FF24345A</Color>
-    <Color x:Key="ErrorColor">#FFF87171</Color>
-    <Color x:Key="HighlightColor">#FF38BDF8</Color>
+    <Color x:Key="PrimaryColor">#FF3B82F6</Color>
+    <Color x:Key="PrimaryVariantColor">#FF1D4ED8</Color>
+    <Color x:Key="SecondaryColor">#FF121C33</Color>
+    <Color x:Key="SecondaryVariantColor">#FF1E3A8A</Color>
+    <Color x:Key="BackgroundStartColor">#FF010409</Color>
+    <Color x:Key="BackgroundEndColor">#FF0B162A</Color>
+    <Color x:Key="SurfaceColor">#FF111B33</Color>
+    <Color x:Key="SurfaceAccentColor">#FF162344</Color>
+    <Color x:Key="SelectorBoxColor">#FF1D2E52</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FF172644</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FF1F2F51</Color>
+    <Color x:Key="ErrorColor">#FFF43F5E</Color>
+    <Color x:Key="HighlightColor">#FF60A5FA</Color>
     <Color x:Key="OnPrimaryColor">#FFF8FAFC</Color>
-    <Color x:Key="OnSecondaryColor">#FFD0E1FF</Color>
+    <Color x:Key="OnSecondaryColor">#FFE2E8F0</Color>
     <Color x:Key="OnBackgroundColor">#FFE2E8F0</Color>
-    <Color x:Key="OnSurfaceColor">#FFDBEAFE</Color>
+    <Color x:Key="OnSurfaceColor">#FFE2E8F0</Color>
     <Color x:Key="TitleTextColor">#FFF8FAFC</Color>
     <Color x:Key="BodyTextColor">#FFC7D2FE</Color>
-    <Color x:Key="MutedTextColor">#FF64748B</Color>
+    <Color x:Key="MutedTextColor">#FF94A3B8</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -46,16 +46,16 @@
     <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
     <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF2F6FEB"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF2B6DEB"/>
     <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF60A5FA"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1F4FCF"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF1E3A8A"/>
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF38BDF8"/>
-    <SolidColorBrush x:Key="DividerBrush" Color="#332F4377"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1C2D4F"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1F4FD1"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF2563EB"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF60A5FA"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#332F4F77"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1C2847"/>
     <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="#FF1D4ED8" Offset="0"/>
-        <GradientStop Color="#FF0F172A" Offset="1"/>
+        <GradientStop Color="#FF0E1B33" Offset="0"/>
+        <GradientStop Color="#FF1E3A8A" Offset="1"/>
     </LinearGradientBrush>
     <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#AA000000"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Dark.xaml
+++ b/ClockifyUtility/Themes/Theme.Dark.xaml
@@ -1,26 +1,26 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Core palette -->
-    <Color x:Key="PrimaryColor">#FF4C9BFF</Color>
-    <Color x:Key="PrimaryVariantColor">#FF1F6FEB</Color>
-    <Color x:Key="SecondaryColor">#FF0B1629</Color>
-    <Color x:Key="SecondaryVariantColor">#FF1B365F</Color>
-    <Color x:Key="BackgroundStartColor">#FF020915</Color>
-    <Color x:Key="BackgroundEndColor">#FF0A1C2F</Color>
-    <Color x:Key="SurfaceColor">#FF112036</Color>
-    <Color x:Key="SurfaceAccentColor">#FF152A45</Color>
-    <Color x:Key="SelectorBoxColor">#FF1D3356</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FF162A47</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FF20375B</Color>
-    <Color x:Key="ErrorColor">#FFFF6B8A</Color>
-    <Color x:Key="HighlightColor">#FF66B9FF</Color>
-    <Color x:Key="OnPrimaryColor">#FFF8FBFF</Color>
-    <Color x:Key="OnSecondaryColor">#FFE1ECFF</Color>
-    <Color x:Key="OnBackgroundColor">#FFD8E6FF</Color>
-    <Color x:Key="OnSurfaceColor">#FFD3E1FF</Color>
+    <Color x:Key="PrimaryColor">#FF4A8BF2</Color>
+    <Color x:Key="PrimaryVariantColor">#FF2E63D6</Color>
+    <Color x:Key="SecondaryColor">#FF0B1424</Color>
+    <Color x:Key="SecondaryVariantColor">#FF173158</Color>
+    <Color x:Key="BackgroundStartColor">#FF050B16</Color>
+    <Color x:Key="BackgroundEndColor">#FF0D1A2E</Color>
+    <Color x:Key="SurfaceColor">#FF111F35</Color>
+    <Color x:Key="SurfaceAccentColor">#FF162843</Color>
+    <Color x:Key="SelectorBoxColor">#FF1D3456</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FF1C2F4F</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FF253C5F</Color>
+    <Color x:Key="ErrorColor">#FFFF6F87</Color>
+    <Color x:Key="HighlightColor">#FF5A99FF</Color>
+    <Color x:Key="OnPrimaryColor">#FFF7FAFF</Color>
+    <Color x:Key="OnSecondaryColor">#FFD9E4FF</Color>
+    <Color x:Key="OnBackgroundColor">#FFD4E0FF</Color>
+    <Color x:Key="OnSurfaceColor">#FFCBD7FF</Color>
     <Color x:Key="TitleTextColor">#FFF1F5FF</Color>
-    <Color x:Key="BodyTextColor">#FFB8CCFF</Color>
-    <Color x:Key="MutedTextColor">#FF8CA3C9</Color>
+    <Color x:Key="BodyTextColor">#FFB5C8F3</Color>
+    <Color x:Key="MutedTextColor">#FF8EA4CA</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -46,16 +46,16 @@
     <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
     <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF2F7DEE"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF66B9FF"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1F6FEB"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF3E8BFF"/>
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF66B9FF"/>
-    <SolidColorBrush x:Key="DividerBrush" Color="#33284760"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1A2C4E"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF3E73E0"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF5A8CFF"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF2F63CF"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF5A99FF"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF5A99FF"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#33213A60"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1B2F4E"/>
     <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="#FF0F223F" Offset="0"/>
-        <GradientStop Color="#FF1F6FEB" Offset="1"/>
+        <GradientStop Color="#FF13213B" Offset="0"/>
+        <GradientStop Color="#FF2C5FB3" Offset="1"/>
     </LinearGradientBrush>
-    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#AA000000"/>
+    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#99000000"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Dark.xaml
+++ b/ClockifyUtility/Themes/Theme.Dark.xaml
@@ -1,0 +1,61 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Core palette -->
+    <Color x:Key="PrimaryColor">#FF2563EB</Color>
+    <Color x:Key="PrimaryVariantColor">#FF1E3A8A</Color>
+    <Color x:Key="SecondaryColor">#FF132A57</Color>
+    <Color x:Key="SecondaryVariantColor">#FF1E40AF</Color>
+    <Color x:Key="BackgroundStartColor">#FF050B19</Color>
+    <Color x:Key="BackgroundEndColor">#FF0F172A</Color>
+    <Color x:Key="SurfaceColor">#FF101D38</Color>
+    <Color x:Key="SurfaceAccentColor">#FF15264B</Color>
+    <Color x:Key="SelectorBoxColor">#FF1B2F57</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FF172A51</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FF24345A</Color>
+    <Color x:Key="ErrorColor">#FFF87171</Color>
+    <Color x:Key="HighlightColor">#FF38BDF8</Color>
+    <Color x:Key="OnPrimaryColor">#FFF8FAFC</Color>
+    <Color x:Key="OnSecondaryColor">#FFD0E1FF</Color>
+    <Color x:Key="OnBackgroundColor">#FFE2E8F0</Color>
+    <Color x:Key="OnSurfaceColor">#FFDBEAFE</Color>
+    <Color x:Key="TitleTextColor">#FFF8FAFC</Color>
+    <Color x:Key="BodyTextColor">#FFC7D2FE</Color>
+    <Color x:Key="MutedTextColor">#FF64748B</Color>
+
+    <!-- Brushes -->
+    <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
+    <SolidColorBrush x:Key="PrimaryVariantBrush" Color="{StaticResource PrimaryVariantColor}"/>
+    <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}"/>
+    <SolidColorBrush x:Key="SecondaryVariantBrush" Color="{StaticResource SecondaryVariantColor}"/>
+    <LinearGradientBrush x:Key="BackgroundBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="{StaticResource BackgroundStartColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource BackgroundEndColor}" Offset="1"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource SurfaceColor}"/>
+    <SolidColorBrush x:Key="SurfaceAccentBrush" Color="{StaticResource SurfaceAccentColor}"/>
+    <SolidColorBrush x:Key="SelectorBoxBrush" Color="{StaticResource SelectorBoxColor}"/>
+    <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="{StaticResource SecondaryButtonBackgroundColor}"/>
+    <SolidColorBrush x:Key="DisabledButtonBackgroundBrush" Color="{StaticResource DisabledButtonBackgroundColor}"/>
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
+    <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}"/>
+    <SolidColorBrush x:Key="OnPrimaryBrush" Color="{StaticResource OnPrimaryColor}"/>
+    <SolidColorBrush x:Key="OnSecondaryBrush" Color="{StaticResource OnSecondaryColor}"/>
+    <SolidColorBrush x:Key="OnBackgroundBrush" Color="{StaticResource OnBackgroundColor}"/>
+    <SolidColorBrush x:Key="OnSurfaceBrush" Color="{StaticResource OnSurfaceColor}"/>
+    <SolidColorBrush x:Key="TitleTextBrush" Color="{StaticResource TitleTextColor}"/>
+    <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
+    <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF2F6FEB"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF60A5FA"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1F4FCF"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF1E3A8A"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF38BDF8"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#332F4377"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1C2D4F"/>
+    <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FF1D4ED8" Offset="0"/>
+        <GradientStop Color="#FF0F172A" Offset="1"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#AA000000"/>
+</ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Dark.xaml
+++ b/ClockifyUtility/Themes/Theme.Dark.xaml
@@ -1,26 +1,26 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Core palette -->
-    <Color x:Key="PrimaryColor">#FF3B82F6</Color>
-    <Color x:Key="PrimaryVariantColor">#FF1D4ED8</Color>
-    <Color x:Key="SecondaryColor">#FF121C33</Color>
-    <Color x:Key="SecondaryVariantColor">#FF1E3A8A</Color>
-    <Color x:Key="BackgroundStartColor">#FF010409</Color>
-    <Color x:Key="BackgroundEndColor">#FF0B162A</Color>
-    <Color x:Key="SurfaceColor">#FF111B33</Color>
-    <Color x:Key="SurfaceAccentColor">#FF162344</Color>
-    <Color x:Key="SelectorBoxColor">#FF1D2E52</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FF172644</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FF1F2F51</Color>
-    <Color x:Key="ErrorColor">#FFF43F5E</Color>
-    <Color x:Key="HighlightColor">#FF60A5FA</Color>
-    <Color x:Key="OnPrimaryColor">#FFF8FAFC</Color>
-    <Color x:Key="OnSecondaryColor">#FFE2E8F0</Color>
-    <Color x:Key="OnBackgroundColor">#FFE2E8F0</Color>
-    <Color x:Key="OnSurfaceColor">#FFE2E8F0</Color>
-    <Color x:Key="TitleTextColor">#FFF8FAFC</Color>
-    <Color x:Key="BodyTextColor">#FFC7D2FE</Color>
-    <Color x:Key="MutedTextColor">#FF94A3B8</Color>
+    <Color x:Key="PrimaryColor">#FF4C9BFF</Color>
+    <Color x:Key="PrimaryVariantColor">#FF1F6FEB</Color>
+    <Color x:Key="SecondaryColor">#FF0B1629</Color>
+    <Color x:Key="SecondaryVariantColor">#FF1B365F</Color>
+    <Color x:Key="BackgroundStartColor">#FF020915</Color>
+    <Color x:Key="BackgroundEndColor">#FF0A1C2F</Color>
+    <Color x:Key="SurfaceColor">#FF112036</Color>
+    <Color x:Key="SurfaceAccentColor">#FF152A45</Color>
+    <Color x:Key="SelectorBoxColor">#FF1D3356</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FF162A47</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FF20375B</Color>
+    <Color x:Key="ErrorColor">#FFFF6B8A</Color>
+    <Color x:Key="HighlightColor">#FF66B9FF</Color>
+    <Color x:Key="OnPrimaryColor">#FFF8FBFF</Color>
+    <Color x:Key="OnSecondaryColor">#FFE1ECFF</Color>
+    <Color x:Key="OnBackgroundColor">#FFD8E6FF</Color>
+    <Color x:Key="OnSurfaceColor">#FFD3E1FF</Color>
+    <Color x:Key="TitleTextColor">#FFF1F5FF</Color>
+    <Color x:Key="BodyTextColor">#FFB8CCFF</Color>
+    <Color x:Key="MutedTextColor">#FF8CA3C9</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -46,16 +46,16 @@
     <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
     <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF2B6DEB"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF60A5FA"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1F4FD1"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF2563EB"/>
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF60A5FA"/>
-    <SolidColorBrush x:Key="DividerBrush" Color="#332F4F77"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1C2847"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF2F7DEE"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF66B9FF"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1F6FEB"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF3E8BFF"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF66B9FF"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#33284760"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FF1A2C4E"/>
     <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="#FF0E1B33" Offset="0"/>
-        <GradientStop Color="#FF1E3A8A" Offset="1"/>
+        <GradientStop Color="#FF0F223F" Offset="0"/>
+        <GradientStop Color="#FF1F6FEB" Offset="1"/>
     </LinearGradientBrush>
     <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#AA000000"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Light.xaml
+++ b/ClockifyUtility/Themes/Theme.Light.xaml
@@ -1,26 +1,26 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Core palette -->
-    <Color x:Key="PrimaryColor">#FF1F6FEB</Color>
-    <Color x:Key="PrimaryVariantColor">#FF0F3DBD</Color>
-    <Color x:Key="SecondaryColor">#FFE6F0FF</Color>
-    <Color x:Key="SecondaryVariantColor">#FF3AA0F3</Color>
-    <Color x:Key="BackgroundStartColor">#FFF6FAFF</Color>
-    <Color x:Key="BackgroundEndColor">#FFE8F1FF</Color>
+    <Color x:Key="PrimaryColor">#FF3A6DDA</Color>
+    <Color x:Key="PrimaryVariantColor">#FF244EB7</Color>
+    <Color x:Key="SecondaryColor">#FFF2F5FB</Color>
+    <Color x:Key="SecondaryVariantColor">#FF2F82D9</Color>
+    <Color x:Key="BackgroundStartColor">#FFF7F9FD</Color>
+    <Color x:Key="BackgroundEndColor">#FFEEF2F9</Color>
     <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
-    <Color x:Key="SurfaceAccentColor">#FFF1F6FF</Color>
-    <Color x:Key="SelectorBoxColor">#FFCFE2FF</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FFDCEAFF</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FFC3D4EE</Color>
-    <Color x:Key="ErrorColor">#FFE44F61</Color>
-    <Color x:Key="HighlightColor">#FF3E8BFF</Color>
+    <Color x:Key="SurfaceAccentColor">#FFEFF3FB</Color>
+    <Color x:Key="SelectorBoxColor">#FFD8E3F7</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FFE1E9F7</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FFC7D2E6</Color>
+    <Color x:Key="ErrorColor">#FFE56A76</Color>
+    <Color x:Key="HighlightColor">#FF4A89F5</Color>
     <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
-    <Color x:Key="OnSecondaryColor">#FF183056</Color>
-    <Color x:Key="OnBackgroundColor">#FF12213B</Color>
-    <Color x:Key="OnSurfaceColor">#FF1D2E4B</Color>
-    <Color x:Key="TitleTextColor">#FF14213D</Color>
-    <Color x:Key="BodyTextColor">#FF334163</Color>
-    <Color x:Key="MutedTextColor">#FF6B7A94</Color>
+    <Color x:Key="OnSecondaryColor">#FF1F2F4A</Color>
+    <Color x:Key="OnBackgroundColor">#FF122038</Color>
+    <Color x:Key="OnSurfaceColor">#FF1A2C4C</Color>
+    <Color x:Key="TitleTextColor">#FF14213C</Color>
+    <Color x:Key="BodyTextColor">#FF2F3F5C</Color>
+    <Color x:Key="MutedTextColor">#FF6B7994</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -46,16 +46,16 @@
     <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
     <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF1F6FEB"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF0F3DBD"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1857D6"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF3E8BFF"/>
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF3AA0F3"/>
-    <SolidColorBrush x:Key="DividerBrush" Color="#142E4A33"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFC6D8F7"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF3A6DDA"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF244EB7"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF2F5FCF"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF4A89F5"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF2F82D9"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#142E4A26"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFD5E1F6"/>
     <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="#FF1B4FCE" Offset="0"/>
-        <GradientStop Color="#FF3AA0F3" Offset="1"/>
+        <GradientStop Color="#FF1E3866" Offset="0"/>
+        <GradientStop Color="#FF2F68C5" Offset="1"/>
     </LinearGradientBrush>
-    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#22102A44"/>
+    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#1A1B2B46"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Light.xaml
+++ b/ClockifyUtility/Themes/Theme.Light.xaml
@@ -1,0 +1,61 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Core palette -->
+    <Color x:Key="PrimaryColor">#FF1D4ED8</Color>
+    <Color x:Key="PrimaryVariantColor">#FF1E40AF</Color>
+    <Color x:Key="SecondaryColor">#FFE5EDFF</Color>
+    <Color x:Key="SecondaryVariantColor">#FF2563EB</Color>
+    <Color x:Key="BackgroundStartColor">#FFF8FAFF</Color>
+    <Color x:Key="BackgroundEndColor">#FFE2E8FF</Color>
+    <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
+    <Color x:Key="SurfaceAccentColor">#FFE9F0FF</Color>
+    <Color x:Key="SelectorBoxColor">#FFD7E3FF</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FFE5EDFF</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FFC6D4F9</Color>
+    <Color x:Key="ErrorColor">#FFDC2626</Color>
+    <Color x:Key="HighlightColor">#FF2563EB</Color>
+    <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
+    <Color x:Key="OnSecondaryColor">#FF1E3A8A</Color>
+    <Color x:Key="OnBackgroundColor">#FF0F172A</Color>
+    <Color x:Key="OnSurfaceColor">#FF1E293B</Color>
+    <Color x:Key="TitleTextColor">#FF0F172A</Color>
+    <Color x:Key="BodyTextColor">#FF334155</Color>
+    <Color x:Key="MutedTextColor">#FF94A3B8</Color>
+
+    <!-- Brushes -->
+    <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
+    <SolidColorBrush x:Key="PrimaryVariantBrush" Color="{StaticResource PrimaryVariantColor}"/>
+    <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}"/>
+    <SolidColorBrush x:Key="SecondaryVariantBrush" Color="{StaticResource SecondaryVariantColor}"/>
+    <LinearGradientBrush x:Key="BackgroundBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="{StaticResource BackgroundStartColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource BackgroundEndColor}" Offset="1"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource SurfaceColor}"/>
+    <SolidColorBrush x:Key="SurfaceAccentBrush" Color="{StaticResource SurfaceAccentColor}"/>
+    <SolidColorBrush x:Key="SelectorBoxBrush" Color="{StaticResource SelectorBoxColor}"/>
+    <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="{StaticResource SecondaryButtonBackgroundColor}"/>
+    <SolidColorBrush x:Key="DisabledButtonBackgroundBrush" Color="{StaticResource DisabledButtonBackgroundColor}"/>
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
+    <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}"/>
+    <SolidColorBrush x:Key="OnPrimaryBrush" Color="{StaticResource OnPrimaryColor}"/>
+    <SolidColorBrush x:Key="OnSecondaryBrush" Color="{StaticResource OnSecondaryColor}"/>
+    <SolidColorBrush x:Key="OnBackgroundBrush" Color="{StaticResource OnBackgroundColor}"/>
+    <SolidColorBrush x:Key="OnSurfaceBrush" Color="{StaticResource OnSurfaceColor}"/>
+    <SolidColorBrush x:Key="TitleTextBrush" Color="{StaticResource TitleTextColor}"/>
+    <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
+    <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF1D4ED8"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF1E40AF"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1A3FB5"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF1E3A8A"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF2563EB"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#11427444"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFC3D1FF"/>
+    <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FFE4ECFF" Offset="0"/>
+        <GradientStop Color="#FFC7D2FE" Offset="1"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#22000000"/>
+</ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Light.xaml
+++ b/ClockifyUtility/Themes/Theme.Light.xaml
@@ -1,26 +1,26 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Core palette -->
-    <Color x:Key="PrimaryColor">#FF0F62FE</Color>
-    <Color x:Key="PrimaryVariantColor">#FF0043CE</Color>
-    <Color x:Key="SecondaryColor">#FFECF2FF</Color>
-    <Color x:Key="SecondaryVariantColor">#FF3056D3</Color>
-    <Color x:Key="BackgroundStartColor">#FFF7F9FC</Color>
-    <Color x:Key="BackgroundEndColor">#FFE8EEFF</Color>
+    <Color x:Key="PrimaryColor">#FF1F6FEB</Color>
+    <Color x:Key="PrimaryVariantColor">#FF0F3DBD</Color>
+    <Color x:Key="SecondaryColor">#FFE6F0FF</Color>
+    <Color x:Key="SecondaryVariantColor">#FF3AA0F3</Color>
+    <Color x:Key="BackgroundStartColor">#FFF6FAFF</Color>
+    <Color x:Key="BackgroundEndColor">#FFE8F1FF</Color>
     <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
-    <Color x:Key="SurfaceAccentColor">#FFF2F6FF</Color>
-    <Color x:Key="SelectorBoxColor">#FFDDE6FF</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FFE7EEFF</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FFC9D5EC</Color>
-    <Color x:Key="ErrorColor">#FFE11D48</Color>
-    <Color x:Key="HighlightColor">#FF1D4ED8</Color>
+    <Color x:Key="SurfaceAccentColor">#FFF1F6FF</Color>
+    <Color x:Key="SelectorBoxColor">#FFCFE2FF</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FFDCEAFF</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FFC3D4EE</Color>
+    <Color x:Key="ErrorColor">#FFE44F61</Color>
+    <Color x:Key="HighlightColor">#FF3E8BFF</Color>
     <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
-    <Color x:Key="OnSecondaryColor">#FF1B2559</Color>
-    <Color x:Key="OnBackgroundColor">#FF0B1120</Color>
-    <Color x:Key="OnSurfaceColor">#FF1D2939</Color>
-    <Color x:Key="TitleTextColor">#FF101828</Color>
-    <Color x:Key="BodyTextColor">#FF344054</Color>
-    <Color x:Key="MutedTextColor">#FF667085</Color>
+    <Color x:Key="OnSecondaryColor">#FF183056</Color>
+    <Color x:Key="OnBackgroundColor">#FF12213B</Color>
+    <Color x:Key="OnSurfaceColor">#FF1D2E4B</Color>
+    <Color x:Key="TitleTextColor">#FF14213D</Color>
+    <Color x:Key="BodyTextColor">#FF334163</Color>
+    <Color x:Key="MutedTextColor">#FF6B7A94</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -46,16 +46,16 @@
     <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
     <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF0F62FE"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF0043CE"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF0040C1"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF1D4ED8"/>
-    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF2563EB"/>
-    <SolidColorBrush x:Key="DividerBrush" Color="#15366633"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFD1DAF3"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF1F6FEB"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF0F3DBD"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1857D6"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF3E8BFF"/>
+    <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF3AA0F3"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#142E4A33"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFC6D8F7"/>
     <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="#FF0F62FE" Offset="0"/>
-        <GradientStop Color="#FF3056D3" Offset="1"/>
+        <GradientStop Color="#FF1B4FCE" Offset="0"/>
+        <GradientStop Color="#FF3AA0F3" Offset="1"/>
     </LinearGradientBrush>
-    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#220F2A44"/>
+    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#22102A44"/>
 </ResourceDictionary>

--- a/ClockifyUtility/Themes/Theme.Light.xaml
+++ b/ClockifyUtility/Themes/Theme.Light.xaml
@@ -1,26 +1,26 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!-- Core palette -->
-    <Color x:Key="PrimaryColor">#FF1D4ED8</Color>
-    <Color x:Key="PrimaryVariantColor">#FF1E40AF</Color>
-    <Color x:Key="SecondaryColor">#FFE5EDFF</Color>
-    <Color x:Key="SecondaryVariantColor">#FF2563EB</Color>
-    <Color x:Key="BackgroundStartColor">#FFF8FAFF</Color>
-    <Color x:Key="BackgroundEndColor">#FFE2E8FF</Color>
+    <Color x:Key="PrimaryColor">#FF0F62FE</Color>
+    <Color x:Key="PrimaryVariantColor">#FF0043CE</Color>
+    <Color x:Key="SecondaryColor">#FFECF2FF</Color>
+    <Color x:Key="SecondaryVariantColor">#FF3056D3</Color>
+    <Color x:Key="BackgroundStartColor">#FFF7F9FC</Color>
+    <Color x:Key="BackgroundEndColor">#FFE8EEFF</Color>
     <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
-    <Color x:Key="SurfaceAccentColor">#FFE9F0FF</Color>
-    <Color x:Key="SelectorBoxColor">#FFD7E3FF</Color>
-    <Color x:Key="SecondaryButtonBackgroundColor">#FFE5EDFF</Color>
-    <Color x:Key="DisabledButtonBackgroundColor">#FFC6D4F9</Color>
-    <Color x:Key="ErrorColor">#FFDC2626</Color>
-    <Color x:Key="HighlightColor">#FF2563EB</Color>
+    <Color x:Key="SurfaceAccentColor">#FFF2F6FF</Color>
+    <Color x:Key="SelectorBoxColor">#FFDDE6FF</Color>
+    <Color x:Key="SecondaryButtonBackgroundColor">#FFE7EEFF</Color>
+    <Color x:Key="DisabledButtonBackgroundColor">#FFC9D5EC</Color>
+    <Color x:Key="ErrorColor">#FFE11D48</Color>
+    <Color x:Key="HighlightColor">#FF1D4ED8</Color>
     <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
-    <Color x:Key="OnSecondaryColor">#FF1E3A8A</Color>
-    <Color x:Key="OnBackgroundColor">#FF0F172A</Color>
-    <Color x:Key="OnSurfaceColor">#FF1E293B</Color>
-    <Color x:Key="TitleTextColor">#FF0F172A</Color>
-    <Color x:Key="BodyTextColor">#FF334155</Color>
-    <Color x:Key="MutedTextColor">#FF94A3B8</Color>
+    <Color x:Key="OnSecondaryColor">#FF1B2559</Color>
+    <Color x:Key="OnBackgroundColor">#FF0B1120</Color>
+    <Color x:Key="OnSurfaceColor">#FF1D2939</Color>
+    <Color x:Key="TitleTextColor">#FF101828</Color>
+    <Color x:Key="BodyTextColor">#FF344054</Color>
+    <Color x:Key="MutedTextColor">#FF667085</Color>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
@@ -46,16 +46,16 @@
     <SolidColorBrush x:Key="BodyTextBrush" Color="{StaticResource BodyTextColor}"/>
     <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource MutedTextColor}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="{StaticResource MutedTextColor}"/>
-    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF1D4ED8"/>
-    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF1E40AF"/>
-    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF1A3FB5"/>
-    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF1E3A8A"/>
+    <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush" Color="#FF0F62FE"/>
+    <SolidColorBrush x:Key="PrimaryButtonBorderBrush" Color="#FF0043CE"/>
+    <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#FF0040C1"/>
+    <SolidColorBrush x:Key="ButtonHoverHighlightBrush" Color="#FF1D4ED8"/>
     <SolidColorBrush x:Key="CustomComboBoxFocusBorderBrush" Color="#FF2563EB"/>
-    <SolidColorBrush x:Key="DividerBrush" Color="#11427444"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFC3D1FF"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#15366633"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#FFD1DAF3"/>
     <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="#FFE4ECFF" Offset="0"/>
-        <GradientStop Color="#FFC7D2FE" Offset="1"/>
+        <GradientStop Color="#FF0F62FE" Offset="0"/>
+        <GradientStop Color="#FF3056D3" Offset="1"/>
     </LinearGradientBrush>
-    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#22000000"/>
+    <SolidColorBrush x:Key="SurfaceShadowBrush" Color="#220F2A44"/>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- add a theme manager that loads light, dark, or system palettes and remembers the user preference
- create refreshed light and dark resource dictionaries and update shared styles to use dynamic resources
- redesign the main window with a modern layout, blue palette, and an in-app theme toggle

## Testing
- `dotnet build ClockifyUtility/ClockifyUtility.csproj` *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f995c26c832dbd9b377147845880